### PR TITLE
Updated readme + remove unused options

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,19 +10,20 @@
       "request": "launch",
       "preLaunchTask": "build",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/src/GDMan.Cli/bin/Debug/net8.0/linux-x64/GDMan.Cli.dll",
+      "program": "${workspaceFolder}/src/GDMan.Cli/bin/Debug/net8.0/linux-x64/gdman.dll",
       "cwd": "${workspaceFolder}/src/GDMan.Cli",
       // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
       "console": "internalConsole",
       "stopAtEntry": false,
       // prettier-ignore
       "args": [
-        "current",
+        // "current",
         // "list"
-        // "install", 
-        "--help",
+        "install", 
+        // "--help",
         // "--latest", 
         // "--flavour", "mono"
+        "--version", "v4.2.2-stable"
       ]
     },
     {

--- a/README.md
+++ b/README.md
@@ -19,118 +19,116 @@ While working with Godot on Linux, I find it a chore having to download new vers
 extract them, rename files and/or create a symbolic link, and having to update
 desktop launchers & config files that point to a previous version.
 I wanted a way to simply run a command and have all this happen behind the scenes.
-And that's exactly what GDMan does.
+
+And that's exactly what GDMan does!
 
 ## Installing GDMan
 
+GDMan is cross-platform and runs in an entirely self-contained folder.
+That means that basically all you have to is download it and run it.
+
 - Download the [latest release](https://github.com/devklick/GDMan/releases/latest)
-  for your operating system and extract it to a folder of your choice, e.g. `~/.local/share/gdman/app/`
-- Update your path, adding your new folder to it. In the above example, we'd add `~/.local/share/gdman/app/` to the PATH.
+  for your operating system and extract it to a folder of your choice, e.g. `~/gdman`.
+- Update your path, adding your new folder to it. In the above example, we'd add `~/gdman` to the PATH.
 
-That's it for now. But after we use GDMan to install a version of Godot, we need to then also:
+This will allow you to invoke two commands from your terminal:
 
-- Update your path, adding
+- `gdman` - for managing versions of Godot
+- `godot` - to run the currently-active version of Godot
+  <br/>
+  **Note that this will not exist until you first install a version of Godot via GDMan**
 
-## Basic CLI
+## Installing versions of Godot
 
-```
-./GDMan.Cli --help
+To install a version of Godot, you run the `install` command.
 
-Command line application for managing versions of Godot
+### Installing latest version
 
-Usage: gdman [command] [command-options]
-
-Commands:
-  install | i - Installs the specified version of Godot
-  list | l - Lists the versions of Godot currently installed on the system
-  current | c - Prints the currently-active version of Godot
-```
-
-## Install Command
+In most cases, you probably want to install the latest version of Godot, so you
+would pass in the `--latest` flag.
 
 ```
-./GDMan.Cli install --help
-
-Supported arguments:
-  --latest, -l
-    Whether or not the latest version should be fetched. If used in conjunction with the Version argument and multiple matching versions are found, the latest of the matches will be used.
-    Type: Boolean Flag (Present (True) or Omitted (False))
-    Default: False
-
-  --version, -v
-    The version to use, e.g. 1.2.3. Any valid semver range is supported
-    Type: String (Valid sematic version range)
-
-  --platform, -p
-    The platform or operating system to find a version for
-    Type: Enum
-      Windows, win, w
-      Linux, lin, l
-      MacOS, mac, osx, m
-    Default: Linux
-
-  --architecture, -a
-    The system architecture to find a version for
-    Type: Enum
-      Arm32
-      Arm64
-      X86
-      X64
-    Default: X64
-
-  --flavour, -f
-    The "flavour" (for lack of a better name) of version to use
-    Type: Enum
-      Standard: The standard version of Godot which uses GDScript
-      Mono: The version of Godot required to use .Net C#
-    Default: Standard
-
-  --directory, -d
-    The directory where the downloaded version should be installed
-    Type: String (Anything)
-    Default: /home/user/.local/share/gdman/versions
-
-  --verbose, -vl
-    Whether or not extensive information should be logged
-    Type: Boolean Flag (Present (True) or Omitted (False))
-    Default: False
-
-  --help, -h
-    Prints the help information to the console
-    Type: Boolean Flag (Present (True) or Omitted (False))
-    Default: False
+gdman install --latest
 ```
 
-## List Command
+> [!NOTE]
+> The shorthard option for `--latest` is `-l`
+
+### Installing an exact version of Godot
+
+If you need more precision to install an exact version of godot, you can pass
+in the `--version` flag with any valid semver value.
 
 ```
-./GDMan.Cli list --help
-
-Supported arguments:
-  --verbose, -vl
-    Whether or not extensive information should be logged
-    Type: Boolean Flag (Present (True) or Omitted (False))
-    Default: False
-
-  --help, -h
-    Prints the help information to the console
-    Type: Boolean Flag (Present (True) or Omitted (False))
-    Default: False
+gdman install --version 4.2.2
 ```
 
-## Current Command
+> The shorthard option for `--version` is `-v`
+
+### Installing mono version
+
+If you need to install the Mono version of Godot, you can do so by passing in the `--flavour` flag option with a value of `mono`.
 
 ```
-./GDMan.Cli current --help
+gdman install --latest --flavour mono
+```
 
-Supported arguments:
-  --verbose, -vl
-    Whether or not extensive information should be logged
-    Type: Boolean Flag (Present (True) or Omitted (False))
-    Default: False
+Alternatively, you can set the `GDMAN_TARGET_FLAVOUR` environment variable to `mono`.
+Doing so means that Mono will be the default flavour whenever the install command runs,
+and to override this with the non-mono version you would override it with the `standard` option.
 
-  --help, -h
-    Prints the help information to the console
-    Type: Boolean Flag (Present (True) or Omitted (False))
-    Default: False
+```
+gdman install --latest --flavour standard
+```
+
+> The shorthard option for `--flavour` is `-f`
+
+### Installing the correct version for your platform
+
+In most cases, GDMan will be able to determine what platform you are running on (Windows, Linux or macOS),
+however you can also specify the platform when running the `install` command.
+
+```
+gdman install --latest --platform mac
+```
+
+You can override the default behaviour by setting the `GDMAN_TARGET_PLATFORM` environment variable
+with the desired platform. Then, whenever you run the `install` command, the value from the
+environment variable will be used, you wont have to specify the `--platform` arg, and
+the app will not attempt to detect the platform you are running on.
+
+> The shorthard option for `--platform` is `-p`
+
+### Installing the correct version for your system architecture
+
+In most cases, GDMan will be able to determine what architecture your system uses (e.g x86, x64 etc).
+However, you can specify the `--architecture` option to specify exactly which archiecture to use.
+
+```
+gdman install --latest --architecture x86
+```
+
+You can override the default behaviour by setting the `GDMAN_TARGET_ARCHITECTURE` environment variable
+with the desired architecture. Then, whenever you run the `install` command, the value from the
+environment variable will be used, you wont have to specify the `--architecture` arg, and
+the app will not attempt to detect the system architecture you are running on.
+
+> The shorthard option for `--architecture` is `-a`
+
+## List all installed versions
+
+To view all of the versions of Godot that are installed on your system, run the `list` command.
+
+```
+gdman list
+```
+
+> This will only list version installed by GDMan
+
+## List active version
+
+To see the version of Godot that is currently active, run the `current` command
+
+```
+gdman current
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ And that's exactly what GDMan does!
 
 ## Installing GDMan
 
-GDMan is cross-platform and runs in an entirely self-contained folder.
+GDMan is cross-platform CLI application that runs in an entirely self-contained folder.
 That means that basically all you have to is download it and run it.
 
 - Download the [latest release](https://github.com/devklick/GDMan/releases/latest)
@@ -45,7 +45,7 @@ To install a version of Godot, you run the `install` command.
 ### Installing latest version
 
 In most cases, you probably want to install the latest version of Godot, so you
-would pass in the `--latest` flag.
+would pass in the `--latest` option.
 
 ```
 gdman install --latest
@@ -57,7 +57,7 @@ gdman install --latest
 ### Installing an exact version of Godot
 
 If you need more precision to install an exact version of godot, you can pass
-in the `--version` flag with any valid semver value.
+in the `--version` option with any valid semver value.
 
 ```
 gdman install --version 4.2.2
@@ -67,7 +67,8 @@ gdman install --version 4.2.2
 
 ### Installing mono version
 
-If you need to install the Mono version of Godot, you can do so by passing in the `--flavour` flag option with a value of `mono`.
+If you need to install the Mono version of Godot, you can do so by passing in
+the `--flavour` option with a value of `mono`.
 
 ```
 gdman install --latest --flavour mono
@@ -85,8 +86,9 @@ gdman install --latest --flavour standard
 
 ### Installing the correct version for your platform
 
-In most cases, GDMan will be able to determine what platform you are running on (Windows, Linux or macOS),
-however you can also specify the platform when running the `install` command.
+In most cases, GDMan will be able to determine what platform you are running on
+(Windows, Linux or macOS), however you can also specify the platform via the
+`--platform` option.
 
 ```
 gdman install --latest --platform mac
@@ -94,7 +96,7 @@ gdman install --latest --platform mac
 
 You can override the default behaviour by setting the `GDMAN_TARGET_PLATFORM` environment variable
 with the desired platform. Then, whenever you run the `install` command, the value from the
-environment variable will be used, you wont have to specify the `--platform` arg, and
+environment variable will be used, you wont have to specify the `--platform` option, and
 the app will not attempt to detect the platform you are running on.
 
 > The shorthard option for `--platform` is `-p`
@@ -102,7 +104,7 @@ the app will not attempt to detect the platform you are running on.
 ### Installing the correct version for your system architecture
 
 In most cases, GDMan will be able to determine what architecture your system uses (e.g x86, x64 etc).
-However, you can specify the `--architecture` option to specify exactly which archiecture to use.
+However, you can use the `--architecture` option to specify exactly which archiecture to use.
 
 ```
 gdman install --latest --architecture x86
@@ -110,7 +112,7 @@ gdman install --latest --architecture x86
 
 You can override the default behaviour by setting the `GDMAN_TARGET_ARCHITECTURE` environment variable
 with the desired architecture. Then, whenever you run the `install` command, the value from the
-environment variable will be used, you wont have to specify the `--architecture` arg, and
+environment variable will be used, you wont have to specify the `--architecture` option, and
 the app will not attempt to detect the system architecture you are running on.
 
 > The shorthard option for `--architecture` is `-a`

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ This will allow you to invoke two commands from your terminal:
 
 To install a version of Godot, you run the `install` command.
 
+> [!WARNING]
+> GDMan does not support versions version of Godot < 4.
+> This is because the naming convention for it's assets changed considerably.
+> Hopefully this naming convention does not change too much in versions 5+ 🤞
+
 ### Installing latest version
 
 In most cases, you probably want to install the latest version of Godot, so you
@@ -52,7 +57,7 @@ gdman install --latest
 ```
 
 > [!NOTE]
-> The shorthard option for `--latest` is `-l`
+> The shorthand option for `--latest` is `-l`
 
 ### Installing an exact version of Godot
 
@@ -63,7 +68,7 @@ in the `--version` option with any valid semver value.
 gdman install --version 4.2.2
 ```
 
-> The shorthard option for `--version` is `-v`
+> The shorthand option for `--version` is `-v`
 
 ### Installing mono version
 
@@ -82,7 +87,7 @@ and to override this with the non-mono version you would override it with the `s
 gdman install --latest --flavour standard
 ```
 
-> The shorthard option for `--flavour` is `-f`
+> The shorthand option for `--flavour` is `-f`
 
 ### Installing the correct version for your platform
 
@@ -94,28 +99,28 @@ In most cases, GDMan will be able to determine what platform you are running on
 gdman install --latest --platform mac
 ```
 
-You can override the default behaviour by setting the `GDMAN_TARGET_PLATFORM` environment variable
+You can override the default behavior by setting the `GDMAN_TARGET_PLATFORM` environment variable
 with the desired platform. Then, whenever you run the `install` command, the value from the
 environment variable will be used, you wont have to specify the `--platform` option, and
 the app will not attempt to detect the platform you are running on.
 
-> The shorthard option for `--platform` is `-p`
+> The shorthand option for `--platform` is `-p`
 
 ### Installing the correct version for your system architecture
 
 In most cases, GDMan will be able to determine what architecture your system uses (e.g x86, x64 etc).
-However, you can use the `--architecture` option to specify exactly which archiecture to use.
+However, you can use the `--architecture` option to specify exactly which architecture to use.
 
 ```
 gdman install --latest --architecture x86
 ```
 
-You can override the default behaviour by setting the `GDMAN_TARGET_ARCHITECTURE` environment variable
+You can override the default behavior by setting the `GDMAN_TARGET_ARCHITECTURE` environment variable
 with the desired architecture. Then, whenever you run the `install` command, the value from the
 environment variable will be used, you wont have to specify the `--architecture` option, and
 the app will not attempt to detect the system architecture you are running on.
 
-> The shorthard option for `--architecture` is `-a`
+> The shorthand option for `--architecture` is `-a`
 
 ## List all installed versions
 

--- a/src/GDMan.Cli/Options/InstallOptions.cs
+++ b/src/GDMan.Cli/Options/InstallOptions.cs
@@ -27,9 +27,6 @@ public class InstallOptions : BaseOptions
     [Option("flavour", "f", "The \"flavour\" (for lack of a better name) of version to use", OptionDataType.Enum)]
     public Flavour Flavour { get; set; } = FlavourHelper.FromEnvVar() ?? Flavour.Standard;
 
-    [Option("directory", "d", "The directory where the downloaded version should be installed", OptionDataType.String)]
-    public string? Directory { get; set; } = KnownPaths.GDManVersionsPath;
-
     public override OptionValidation Validate()
     {
         if (Version == null && !Latest)


### PR DESCRIPTION
## Remove `Directory` option from the `Install` command. 
This was leftover from an earlier iteration of the application. Since I've gone in different direction where GDMan runs entirely in it's own self-contained folder, specifying the directory to install versions to is no longer supported.

## Docs
Updated readme