### PR TITLE
fix: fixes #11 - sequence contains no elements when no args provided

### DIFF
--- a/src/GDMan.Cli/Parsing/Parser.cs
+++ b/src/GDMan.Cli/Parsing/Parser.cs
@@ -21,10 +21,14 @@ public class Parser(ConsoleLogger logger)
 
         var result = new ParseResult();
 
-        var arg1 = args.First();
+        var arg1 = args.FirstOrDefault();
         if (!TryInitCommandOptions(arg1, out var options, out var helpInfo))
         {
-            result.Errors.Add($"{arg1} is not a known command");
+            if (!string.IsNullOrEmpty(arg1))
+            {
+                result.Errors.Add($"{arg1} is not a known command");
+            }
+
             result.HelpInfo = helpInfo;
             result.RequiresHelp = true;
             return result;

--- a/src/GDMan.Cli/Program.cs
+++ b/src/GDMan.Cli/Program.cs
@@ -47,24 +47,24 @@ class Program
         }
     }
 
-    private static async Task HandleParseResult(ParseResult cliArgs)
+    private static async Task HandleParseResult(ParseResult result)
     {
-        if (cliArgs.RequiresHelp)
+        if (result.HasError)
         {
-            HandleHelp(cliArgs);
+            HandleError(result);
         }
 
-        if (cliArgs.HasError)
+        if (result.RequiresHelp)
         {
-            HandleError(cliArgs);
+            HandleHelp(result);
         }
 
-        if (cliArgs.Options == null)
+        if (result.Options == null)
         {
             throw new NullReferenceException("Expected Options to have a value but found null");
         }
 
-        await RunAsync(cliArgs.Options);
+        await RunAsync(result.Options);
     }
 
     private static Task RunAsync(BaseOptions command) => command switch
@@ -138,10 +138,10 @@ class Program
     }
 
     [DoesNotReturn]
-    private static void HandleError(ParseResult cliArgs)
+    private static void HandleError(ParseResult result)
     {
-        _logger.LogError(string.Join(Environment.NewLine, new List<string>(cliArgs.Errors.Append(Environment.NewLine))));
-        _logger.LogInformation(cliArgs.HelpInfoString);
+        _logger.LogError(string.Join(Environment.NewLine, new List<string>(result.Errors.Append(""))));
+        _logger.LogInformation(result.HelpInfoString);
         Environment.Exit(1);
     }
 


### PR DESCRIPTION
- Use FirstOrDefault to handle the the case where the list is empty
- Only add an error to the list if a command was provided and is invalid