### PR TITLE
Create godot shortcut rather than symlink on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Once you have GDMan installed, you should be able to invoke the following two co
 - `godot` - to run the currently-active version of Godot
   <br/>
   **Note that the latter will not exist until you first install a version of Godot via GDMan**
+  <br/>
+  **Note that on Windows, you may need to use `godot.lnk` rather than just `godot`**
 
 ## Installing versions of Godot
 

--- a/src/GDMan.Core/Services/GodotService.cs
+++ b/src/GDMan.Core/Services/GodotService.cs
@@ -33,7 +33,7 @@ public class GodotService(GithubApiService github, ConsoleLogger logger, GDManDi
             if (_gdman.GDManVersionsDirectory.AlreadyInstalled(versionName, out versionDir))
             {
                 _logger.LogInformation($"Version {versionName} already installed, setting active");
-                _gdman.SetActive(versionDir);
+                await _gdman.SetActive(versionDir);
                 return new Result<object>(ResultStatus.OK, null);
             }
         }
@@ -73,7 +73,7 @@ public class GodotService(GithubApiService github, ConsoleLogger logger, GDManDi
         if (_gdman.GDManVersionsDirectory.AlreadyInstalled(versionName, out versionDir))
         {
             _logger.LogInformation($"Version {versionName} already installed, setting active");
-            _gdman.SetActive(versionDir);
+            await _gdman.SetActive(versionDir);
             return new Result<object>(ResultStatus.OK, null);
         }
         // -------------------------------------------------
@@ -86,7 +86,7 @@ public class GodotService(GithubApiService github, ConsoleLogger logger, GDManDi
 
         versionDir = await _gdman.GDManVersionsDirectory.Install(downloadUrl, versionName);
 
-        _gdman.SetActive(versionDir);
+        await _gdman.SetActive(versionDir);
         // -------------------------------------------------
 
         return new Result<object>();


### PR DESCRIPTION
Update to create a shortcut rather than a symlink on Windows. This fixes #20. 

The approach taken is pretty hacky, but it should do for now. It depends on PowerShell, which in most cases should be installed on the host system. 

Note that it's possible to resolve this issue by continuing to create a symlink and just appending `.exe` onto it. It can then be invoked from the terminal. However, admin privileges are required to create the symlinks, meaning that the user would always have to run `gdman` from an elevated command prompt. Since elevated permissions are not required to create a shortcut, I feel like this the better approach. 

The downside with using a shortcut is that you need to invoke `godot.lnk` to start the program, rather than just `godot`. It's possible to change this behavior by adding .LNK to the `PATHEXT` environment variable ([see here](https://www.nextofwindows.com/what-is-pathext-environment-variable-in-windows)).