### PR TITLE
Feature #29  - Get current gdman version

### DIFF
--- a/src/GDMan.Cli/Help/AppHelpInfo.cs
+++ b/src/GDMan.Cli/Help/AppHelpInfo.cs
@@ -1,5 +1,7 @@
 using System.Data;
 
+using GDMan.Cli.Version;
+
 namespace GDMan.Cli.Help;
 
 /// <summary>
@@ -10,11 +12,10 @@ namespace GDMan.Cli.Help;
 public class AppHelpInfo : CliHelpInfo
 {
     public static string AppName => "GDMan";
-    public static SemanticVersioning.Version? AppVersion => GetVersion();
     public static string AppDescription => "Command line application for managing versions of Godot";
     public List<(string FullName, string ShortName, string Description)> KnownCommands { get; set; } = [];
     public override string ToString()
-        => $"{AppName} {(AppVersion != null ? $"(v{AppVersion})" : "")}"
+        => $"{AppName} {CliVersionInfo.ToString()}"
         + Environment.NewLine
         + AppDescription
         + Environment.NewLine + Environment.NewLine
@@ -25,13 +26,4 @@ public class AppHelpInfo : CliHelpInfo
         + string.Join(Environment.NewLine, KnownCommands.Select(c => $"  {c.FullName} | {c.ShortName} - {c.Description}"))
         + Environment.NewLine + Environment.NewLine
         + "Run 'gdman [command] --help' for more information on a command";
-
-    private static SemanticVersioning.Version? GetVersion()
-    {
-        var version = typeof(CliHelpInfo).Assembly.GetName().Version;
-
-        return version == null
-            ? null
-            : SemanticVersioning.Version.Parse($"{version.Major}.{version.Minor}.{version.Build}");
-    }
 }

--- a/src/GDMan.Cli/Help/AppHelpInfo.cs
+++ b/src/GDMan.Cli/Help/AppHelpInfo.cs
@@ -10,13 +10,11 @@ namespace GDMan.Cli.Help;
 public class AppHelpInfo : CliHelpInfo
 {
     public static string AppName => "GDMan";
-    public static string AppVersion =>
-        typeof(CliHelpInfo).Assembly.GetName().Version?.ToString()
-        ?? throw new VersionNotFoundException("Unable to determine the application version");
+    public static SemanticVersioning.Version? AppVersion => GetVersion();
     public static string AppDescription => "Command line application for managing versions of Godot";
     public List<(string FullName, string ShortName, string Description)> KnownCommands { get; set; } = [];
     public override string ToString()
-        => $"{AppName} (v{AppVersion})"
+        => $"{AppName} {(AppVersion != null ? $"(v{AppVersion})" : "")}"
         + Environment.NewLine
         + AppDescription
         + Environment.NewLine + Environment.NewLine
@@ -27,4 +25,13 @@ public class AppHelpInfo : CliHelpInfo
         + string.Join(Environment.NewLine, KnownCommands.Select(c => $"  {c.FullName} | {c.ShortName} - {c.Description}"))
         + Environment.NewLine + Environment.NewLine
         + "Run 'gdman [command] --help' for more information on a command";
+
+    private static SemanticVersioning.Version? GetVersion()
+    {
+        var version = typeof(CliHelpInfo).Assembly.GetName().Version;
+
+        return version == null
+            ? null
+            : SemanticVersioning.Version.Parse($"{version.Major}.{version.Minor}.{version.Build}");
+    }
 }

--- a/src/GDMan.Cli/Help/CliHelpInfo.cs
+++ b/src/GDMan.Cli/Help/CliHelpInfo.cs
@@ -4,4 +4,5 @@ public class CliHelpInfo
 {
     public static readonly string FullName = "--help";
     public static readonly string ShortName = "-h";
+    public static readonly string[] Names = [FullName, ShortName];
 }

--- a/src/GDMan.Cli/Parsing/ParseResult.cs
+++ b/src/GDMan.Cli/Parsing/ParseResult.cs
@@ -7,6 +7,7 @@ public class ParseResult
 {
     public BaseOptions? Options { get; set; }
     public bool RequiresHelp { get; set; }
+    public bool RequiresVersion { get; set; }
     public CliHelpInfo? HelpInfo { get; set; }
     public string HelpInfoString => HelpInfo?.ToString() ?? throw new NullReferenceException("Expected HelpInfo to have a value but found null");
     public List<string> Errors { get; set; } = [];

--- a/src/GDMan.Cli/Program.cs
+++ b/src/GDMan.Cli/Program.cs
@@ -8,6 +8,7 @@ using GDMan.Core.Services.Github;
 using GDMan.Core.Services.FileSystem;
 using GDMan.Core.Infrastructure;
 using GDMan.Core.Models;
+using GDMan.Cli.Version;
 
 namespace GDMan.Cli;
 
@@ -57,6 +58,11 @@ class Program
         if (result.RequiresHelp)
         {
             HandleHelp(result);
+        }
+
+        if (result.RequiresVersion)
+        {
+            HandleVersion(result);
         }
 
         if (result.Options == null)
@@ -134,6 +140,13 @@ class Program
     private static void HandleHelp(ParseResult cliArgs)
     {
         _logger.LogInformation(cliArgs.HelpInfoString);
+        Environment.Exit(0);
+    }
+
+    [DoesNotReturn]
+    private static void HandleVersion(ParseResult parseResult)
+    {
+        _logger.LogInformation(CliVersionInfo.ToString());
         Environment.Exit(0);
     }
 

--- a/src/GDMan.Cli/Version/CliVersionInfo.cs
+++ b/src/GDMan.Cli/Version/CliVersionInfo.cs
@@ -1,0 +1,21 @@
+namespace GDMan.Cli.Version;
+
+public class CliVersionInfo
+{
+    public static readonly string FullName = "--version";
+    public static readonly string ShortName = "-v";
+    public static readonly string[] Names = [FullName, ShortName];
+
+    public static SemanticVersioning.Version? AppVersion => GetVersion();
+    private static SemanticVersioning.Version? GetVersion()
+    {
+        var version = typeof(CliVersionInfo).Assembly.GetName().Version;
+
+        return version == null
+            ? null
+            : SemanticVersioning.Version.Parse($"{version.Major}.{version.Minor}.{version.Build}");
+    }
+
+    public new static string ToString()
+        => AppVersion?.ToString() ?? "unknown version";
+}


### PR DESCRIPTION
Added support to print current version of GDMan. 

Usage:
```sh
gdman --version
# or
gdman -v
```