### PR TITLE
Feature - Check for updates

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,8 +25,9 @@
         // "--latest", 
         // "--flavour", "mono",
         // "--version", "4.2.x",
-        "uninstall", "--unused"
+        // "uninstall", "--unused"
         // "install", "--version", "4.1.3-stable", "-a", "arm32"
+        "update", "--help"
       ]
     },
     {

--- a/src/GDMan.Cli/Options/UpdateOptions.cs
+++ b/src/GDMan.Cli/Options/UpdateOptions.cs
@@ -1,0 +1,9 @@
+using GDMan.Cli.Attributes;
+
+namespace GDMan.Cli.Options;
+
+[Command("update", "u", "Checks if any GDMan updates are available")]
+public class UpdateOptions : BaseOptions
+{
+
+}

--- a/src/GDMan.Cli/Parsing/Parser.cs
+++ b/src/GDMan.Cli/Parsing/Parser.cs
@@ -132,6 +132,9 @@ public class Parser(ConsoleLogger logger)
         if (TryInitCommandOptions<UninstallOptions>(arg1, out var uninstall, ref helpInfo))
             returnOptions = uninstall;
 
+        if (TryInitCommandOptions<UpdateOptions>(arg1, out var update, ref helpInfo))
+            returnOptions = update;
+
         options = returnOptions;
 
         return options != null;

--- a/src/GDMan.Cli/Program.cs
+++ b/src/GDMan.Cli/Program.cs
@@ -18,6 +18,7 @@ class Program
 #pragma warning disable IDE1006 // Naming Styles
     private static ServiceProvider _serviceProvider;
     private static GodotService _godot;
+    private static UpdateCheckerService _updateChecker;
     private static ConsoleLogger _logger;
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 #pragma warning restore IDE1006 // Naming Styles
@@ -37,13 +38,13 @@ class Program
 
         _logger = _serviceProvider.GetRequiredService<ConsoleLogger>();
         _godot = _serviceProvider.GetRequiredService<GodotService>();
+        _updateChecker = _serviceProvider.GetRequiredService<UpdateCheckerService>();
 
-        var updateChecker = _serviceProvider.GetRequiredService<UpdateCheckerService>();
         var parser = _serviceProvider.GetRequiredService<Parser>();
 
         try
         {
-            await updateChecker.CheckForUpdates();
+            await _updateChecker.CheckForUpdatesIfDue();
             await HandleParseResult(parser.Parse(args));
         }
         catch (Exception ex)
@@ -83,6 +84,7 @@ class Program
         ListOptions i => RunListAsync(i),
         CurrentOptions i => RunCurrentAsync(i),
         UninstallOptions i => RunUninstallAsync(i),
+        UpdateOptions i => RunUpdateAsync(i),
         _ => throw new InvalidOperationException()
     };
 
@@ -106,7 +108,7 @@ class Program
 
     private static async Task RunInstallAsync(InstallOptions command)
     {
-        _logger.LogTrace($"Processing install command");
+        _logger.LogTrace("Processing install command");
 
         var result = await _godot.InstallAsync(
             command.Version,
@@ -123,7 +125,7 @@ class Program
 
     private static async Task RunListAsync(ListOptions command)
     {
-        _logger.LogTrace($"Processing list command");
+        _logger.LogTrace("Processing list command");
 
         await _godot.ListAsync();
 
@@ -132,11 +134,20 @@ class Program
 
     private static async Task RunCurrentAsync(CurrentOptions command)
     {
-        _logger.LogTrace($"Processing current command");
+        _logger.LogTrace("Processing current command");
 
         await _godot.GetCurrentVersion();
 
-        _logger.LogTrace($"Done");
+        _logger.LogTrace("Done");
+    }
+
+    private static async Task RunUpdateAsync(UpdateOptions command)
+    {
+        _logger.LogTrace("Processing current command");
+
+        await _updateChecker.CheckForUpdates();
+
+        _logger.LogTrace("Done");
     }
 
 

--- a/src/GDMan.Cli/Program.cs
+++ b/src/GDMan.Cli/Program.cs
@@ -27,6 +27,8 @@ class Program
             .AddSingleton(new ConsoleLogger(args.Contains("--verbose") || args.Contains("-vl") ? LogLevel.Trace : LogLevel.Information))
             .AddSingleton<GithubApiService>()
             .AddSingleton<GodotService>()
+            .AddSingleton<UpdateCheckerService>()
+            .AddSingleton<GDManRepoService>()
             .AddSingleton<Parser>()
             .AddSingleton<GDManDirectory>()
             .AddSingleton<GDManVersionsDirectory>()
@@ -35,10 +37,12 @@ class Program
         _logger = _serviceProvider.GetRequiredService<ConsoleLogger>();
         _godot = _serviceProvider.GetRequiredService<GodotService>();
 
+        var updateChecker = _serviceProvider.GetRequiredService<UpdateCheckerService>();
         var parser = _serviceProvider.GetRequiredService<Parser>();
 
         try
         {
+            await updateChecker.CheckForUpdates();
             await HandleParseResult(parser.Parse(args));
         }
         catch (Exception ex)

--- a/src/GDMan.Core/Config/EnvVars.cs
+++ b/src/GDMan.Core/Config/EnvVars.cs
@@ -11,4 +11,5 @@ public static class EnvVars
     public static readonly EnvVar TargetArchitecture = new("GDMAN_TARGET_ARCHITECTURE");
     public static readonly EnvVar TargetPlatform = new("GDMAN_TARGET_PLATFORM");
     public static readonly EnvVar TargetFlavour = new("GDMAN_TARGET_FLAVOUR");
+    public static readonly EnvVar LastCheckedForUpdates = new("GDMAN_LAST_CHECKED_FOR_UPDATES");
 }

--- a/src/GDMan.Core/Infrastructure/ConsoleLogger.cs
+++ b/src/GDMan.Core/Infrastructure/ConsoleLogger.cs
@@ -46,4 +46,6 @@ public class ConsoleLogger(LogLevel minLogLevel = LogLevel.Information)
         Console.BackgroundColor = backOld;
         Console.ForegroundColor = frontOld;
     }
+
+    public void NewLine(LogLevel level = LogLevel.Information) => Log(level, "");
 }

--- a/src/GDMan.Core/Models/GDManVersionInfo.cs
+++ b/src/GDMan.Core/Models/GDManVersionInfo.cs
@@ -1,0 +1,8 @@
+
+namespace GDMan.Core.Models;
+
+public class GDManVersionInfo(SemanticVersioning.Version version, string releaseUrl)
+{
+    public SemanticVersioning.Version Version { get; set; } = version;
+    public string ReleaseUrl { get; set; } = releaseUrl;
+}

--- a/src/GDMan.Core/Services/Github/GDManRepoService.cs
+++ b/src/GDMan.Core/Services/Github/GDManRepoService.cs
@@ -1,0 +1,44 @@
+using GDMan.Core.Infrastructure;
+using GDMan.Core.Models;
+
+namespace GDMan.Core.Services.Github;
+
+public class GDManRepoService(GithubApiService githubApiService, ConsoleLogger logger)
+{
+    private readonly GithubApiService _githubApiService = githubApiService;
+    private readonly ConsoleLogger _logger = logger;
+
+    public async Task<Result<GDManVersionInfo>> GetLatestVersion()
+    {
+        var result = await _githubApiService.GetReleasesAsync("devklick", "gdman");
+
+        if (result.Status != ResultStatus.OK || result.Value == null)
+        {
+            return new Result<GDManVersionInfo>
+            {
+                Error = ["Error checking for updates"],
+                Messages = result.Messages,
+                Status = ResultStatus.ServerError,
+            };
+        }
+
+        // We should be able to assume the first item in the array is the latest release, 
+        // however lets order them to make sure. This increases confidence but also increases
+        // execution time as more and more versions are published. Might want to address this in the future.
+        var latest = result.Value.OrderByDescending(r => r.PublishedAt).FirstOrDefault();
+
+        if (latest == null)
+        {
+            return new Result<GDManVersionInfo>
+            {
+                Error = ["Error checking for updates"],
+            };
+        }
+
+        return new()
+        {
+            Status = ResultStatus.OK,
+            Value = new(SemanticVersioning.Version.Parse(latest.TagName), latest.HtmlUrl)
+        };
+    }
+}

--- a/src/GDMan.Core/Services/GodotService.cs
+++ b/src/GDMan.Core/Services/GodotService.cs
@@ -109,7 +109,7 @@ public class GodotService(GithubApiService github, ConsoleLogger logger, GDManDi
         }
         else
         {
-            _logger.LogInformation("No versions installed. To instal a version of Godot, run: gdman install");
+            _logger.LogInformation("No versions installed. To install a version of Godot, run: gdman install");
         }
 
 

--- a/src/GDMan.Core/Services/UpdateCheckerService.cs
+++ b/src/GDMan.Core/Services/UpdateCheckerService.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 
+using GDMan.Core.Config;
 using GDMan.Core.Infrastructure;
 using GDMan.Core.Models;
 using GDMan.Core.Services.Github;
@@ -13,9 +14,19 @@ public class UpdateCheckerService(GDManRepoService gdmanRepoService, ConsoleLogg
     private readonly GDManRepoService _gdmanRepoService = gdmanRepoService;
     private readonly ConsoleLogger _logger = logger;
 
+    /// <summary>
+    /// Whether or not we have checked for updates during the current process.
+    /// </summary>
+    public bool Checked { get; private set; }
+
 
     public async Task CheckForUpdates()
     {
+        // The check may have already happened on schedule
+        // and we may now be trying to perform the check on user request. 
+        // Skip if we've already performed the check in the current process.
+        if (Checked) return;
+
         var result = await _gdmanRepoService.GetLatestVersion();
 
         if (result.Status != ResultStatus.OK || result.Value == null)
@@ -30,7 +41,13 @@ public class UpdateCheckerService(GDManRepoService gdmanRepoService, ConsoleLogg
         if (currentVersion == null)
         {
             _logger.LogError("Cant determine current version of GDMan. Unable to check for updates");
+            return;
         }
+
+        // DOESNT WORK ON LINUX - env vars only persisted in current process.
+        // TODO: use config file instead
+        Environment.SetEnvironmentVariable(EnvVars.LastCheckedForUpdates.Name, DateTime.UtcNow.ToString(), EnvironmentVariableTarget.User);
+        Checked = true;
 
         var latest = result.Value;
 
@@ -44,6 +61,28 @@ public class UpdateCheckerService(GDManRepoService gdmanRepoService, ConsoleLogg
         }
 
         _logger.LogInformation("Already on latest version");
+    }
+
+    public async Task CheckForUpdatesIfDue()
+    {
+        if (AutoUpdateCheckDue())
+        {
+            await CheckForUpdates();
+        }
+    }
+
+    private bool AutoUpdateCheckDue()
+    {
+        // temporarily disable auto checking until we can persist
+        // the last check date in config file so it's cross-platform
+        return false;
+
+        // var envVar = EnvVars.LastCheckedForUpdates.Value;
+        // if (string.IsNullOrEmpty(envVar)) return true;
+        // if (!DateTime.TryParse(EnvVars.LastCheckedForUpdates.Value, out var lastChecked)) return true;
+        // // Ideally should make the frequency configurable. Maybe in a future version...
+        // if (lastChecked.AddDays(7) < DateTime.UtcNow) return true;
+        // return false;
     }
 
     private static SemanticVersioning.Version? GetCurrentVersion()

--- a/src/GDMan.Core/Services/UpdateCheckerService.cs
+++ b/src/GDMan.Core/Services/UpdateCheckerService.cs
@@ -1,0 +1,79 @@
+using System.Reflection;
+
+using GDMan.Core.Infrastructure;
+using GDMan.Core.Models;
+using GDMan.Core.Services.Github;
+
+using SharpCompress;
+
+namespace GDMan.Core.Services;
+
+public class UpdateCheckerService(GDManRepoService gdmanRepoService, ConsoleLogger logger)
+{
+    private readonly GDManRepoService _gdmanRepoService = gdmanRepoService;
+    private readonly ConsoleLogger _logger = logger;
+
+
+    public async Task CheckForUpdates()
+    {
+        var result = await _gdmanRepoService.GetLatestVersion();
+
+        if (result.Status != ResultStatus.OK || result.Value == null)
+        {
+            result.Messages.ForEach(_logger.LogError);
+            result.Error?.ForEach(_logger.LogError);
+            _logger.NewLine();
+            return;
+        }
+        var currentVersion = GetCurrentVersion();
+
+        if (currentVersion == null)
+        {
+            _logger.LogError("Cant determine current version of GDMan. Unable to check for updates");
+        }
+
+        var latest = result.Value;
+
+        if (latest.Version > currentVersion)
+        {
+            _logger.LogInformation($"Version {latest.Version} is available!");
+            _logger.LogInformation($"To see changelog, visit {latest.ReleaseUrl}");
+            GetUpdateInstructions().ForEach(_logger.LogInformation);
+            _logger.NewLine();
+            return;
+        }
+
+        _logger.LogInformation("Already on latest version");
+    }
+
+    private static SemanticVersioning.Version? GetCurrentVersion()
+    {
+        var versionString = Assembly.GetExecutingAssembly().GetName().Version?.ToString();
+
+        return string.IsNullOrEmpty(versionString)
+            ? null
+            : SemanticVersioning.Version.Parse(versionString, loose: true);
+    }
+
+    private static string[] GetUpdateInstructions()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return [
+                "Run the following in PowerShell to update:",
+                ". {iwr -useb https://raw.githubusercontent.com/devklick/GDMan/master/install/install-windows.ps1} | iex;"
+            ];
+        }
+        if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
+        {
+            var os = OperatingSystem.IsLinux() ? "linux" : "osx";
+            return [
+                "Run the following to update:",
+                $"wget -q https://raw.githubusercontent.com/devklick/GDMan/master/install/install-unix.sh -O - | bash -s {os}"
+            ];
+        }
+        return [
+            "You can manually download and install the correct version for your operating system from here"
+        ];
+    }
+}

--- a/src/GDMan.Core/Services/UpdateCheckerService.cs
+++ b/src/GDMan.Core/Services/UpdateCheckerService.cs
@@ -27,6 +27,8 @@ public class UpdateCheckerService(GDManRepoService gdmanRepoService, ConsoleLogg
         // Skip if we've already performed the check in the current process.
         if (Checked) return;
 
+        _logger.LogInformation("Checking for updates");
+
         var result = await _gdmanRepoService.GetLatestVersion();
 
         if (result.Status != ResultStatus.OK || result.Value == null)
@@ -61,6 +63,7 @@ public class UpdateCheckerService(GDManRepoService gdmanRepoService, ConsoleLogg
         }
 
         _logger.LogInformation("Already on latest version");
+        _logger.NewLine();
     }
 
     public async Task CheckForUpdatesIfDue()

--- a/src/GDMan.Core/Services/WebApiService.cs
+++ b/src/GDMan.Core/Services/WebApiService.cs
@@ -30,7 +30,7 @@ public class WebApiService(HttpClient client)
         {
             var endpoint = BuildEndpointUrl(baseUrl, controller, action, queryParameters, trimTrailingSlash);
             var httpResponse = await _client.GetAsync(endpoint);
-            result = await ProcessResponse<T, TError>(httpResponse, successTypeInfo, errorTypeInfo);
+            result = await ProcessResponse(httpResponse, successTypeInfo, errorTypeInfo);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Added new command that allows us to see the current version of GDMan we're using.

Usage:
```sh
gdman update
# or gdman u
```

Closes #24

A further update will enable a related feature where the app will automatically check for updates every now and then, however this is currently disabled as some refactoring is needed before that can happen.