### PR TITLE
fix: identify if new version is available

### DIFF
--- a/src/GDMan.Core/Services/Github/GDManRepoService.cs
+++ b/src/GDMan.Core/Services/Github/GDManRepoService.cs
@@ -38,7 +38,7 @@ public class GDManRepoService(GithubApiService githubApiService, ConsoleLogger l
         return new()
         {
             Status = ResultStatus.OK,
-            Value = new(SemanticVersioning.Version.Parse(latest.TagName), latest.HtmlUrl)
+            Value = new(SemanticVersioning.Version.Parse(latest.TagName, true), latest.HtmlUrl)
         };
     }
 }

--- a/src/GDMan.Core/Services/UpdateCheckerService.cs
+++ b/src/GDMan.Core/Services/UpdateCheckerService.cs
@@ -90,11 +90,13 @@ public class UpdateCheckerService(GDManRepoService gdmanRepoService, ConsoleLogg
 
     private static SemanticVersioning.Version? GetCurrentVersion()
     {
-        var versionString = Assembly.GetExecutingAssembly().GetName().Version?.ToString();
+        var version = Assembly.GetExecutingAssembly().GetName().Version;
 
-        return string.IsNullOrEmpty(versionString)
-            ? null
-            : SemanticVersioning.Version.Parse(versionString, loose: true);
+        if (version == null) return null;
+
+        var versionString = $"{version.Major}.{version.Minor}.{version.Build}";
+
+        return SemanticVersioning.Version.Parse(versionString);
     }
 
     private static string[] GetUpdateInstructions()


### PR DESCRIPTION
Fixes an issue where the comparison between the current installed and latest available version was incorrect, causing the user to be advised an update was available and directs them to the same version they are currently on. 

This was happening because the published version was is `{maj}.{min}.{patch}` but the version baked into the C# assembly is `{maj}.{min}.{build}.{revision}`. This fourth part, revision, was causing semver to treat it as a pre-re-release. This mean that 1.7.0.0 is a pre-release version of 1.7.0, i.e. comes _before_ it, so 1.7.0 was seen as a later version of 1.7.0.0.

The fix here is just to only take the maj, max, build from the C# assembly version and construct the expected semver string with that.This is fine for now, until pre-releases start getting introduced. I've decided to ignore this for now, as I'm not sure how pre-release flags would get baked into the C# assembly, so not sure how to handle that (or if I'll ever need to handle it).